### PR TITLE
Refactor animalDetections to a structured list of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ The `ai_mongo_operations.py` script will add or update an `aiResults` field in y
       "runDate": "2025-06-08",
       "confBlank": 0.0,
       "confHuman": 0.0,
-      "confAnimal": 0.95
+      "confAnimal": 0.95,
+      "animalDetections": [
+        {
+          "bbox": [0.1, 0.2, 0.3, 0.4],
+          "conf": 0.95
+        }
+      ]
     }
     // ... other AI results may be present if using 'update' ...
   ]

--- a/ai_results/ai_detection_parser.py
+++ b/ai_results/ai_detection_parser.py
@@ -41,13 +41,16 @@ def parse_detections(json_file: str, num_samples: Optional[int] = None) -> Dict[
         run_date = pred.get("run_date", "unknown")
 
         animal_confs = []
-        animal_boxes = []
+        animal_detections = []
         human_confs = []
 
         for det in detections:
             if det["label"] == "animal":
                 animal_confs.append(float(det["conf"]))
-                animal_boxes.append(det["bbox"])
+                animal_detections.append({
+                    "bbox": det["bbox"],
+                    "conf": float(det["conf"])
+                })
             elif det["label"] == "human":
                 human_confs.append(float(det["conf"]))
 
@@ -73,7 +76,7 @@ def parse_detections(json_file: str, num_samples: Optional[int] = None) -> Dict[
             "confBlank": conf_blank,
             "confHuman": conf_human,
             "confAnimal": conf_animal,
-            "animalDetections": animal_boxes
+            "animalDetections": animal_detections
         }
 
         results[media_id] = {

--- a/test_predictions.json
+++ b/test_predictions.json
@@ -1,0 +1,28 @@
+{
+  "predictions": [
+    {
+      "filepath": "test_image_1.jpg",
+      "run_date": "2024-03-29",
+      "detections": [
+        {
+          "category": "1",
+          "label": "animal",
+          "conf": 0.95,
+          "bbox": [0.1, 0.2, 0.3, 0.4]
+        },
+        {
+          "category": "1",
+          "label": "animal",
+          "conf": 0.85,
+          "bbox": [0.5, 0.6, 0.1, 0.1]
+        },
+        {
+          "category": "2",
+          "label": "human",
+          "conf": 0.75,
+          "bbox": [0.0, 0.0, 0.1, 0.1]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The `animalDetections` field in `aiResults` has been refactored from a simple list of bounding boxes to a list of objects, each containing both the `bbox` and the `conf` score. This change supports the requirement to draw boxes with confidence data on the frontend. The `ai_results/ai_detection_parser.py` script was updated to implement this change, and the `README.md` was updated to reflect the new document structure. A `test_predictions.json` file was also added to demonstrate the expected input and verify the output.

---
*PR created automatically by Jules for task [14316367411674083415](https://jules.google.com/task/14316367411674083415) started by @morescode-pm*